### PR TITLE
Add exception in renderer to allow for test runner

### DIFF
--- a/rest_framework_ember_3/renderers.py
+++ b/rest_framework_ember_3/renderers.py
@@ -20,10 +20,14 @@ class JSONRenderer(renderers.JSONRenderer):
     }
     """
     def render(self, data, accepted_media_type=None, renderer_context=None):
-        view = renderer_context.get('view')
-        resource_name = get_resource_name(view)
+        try:
+            view = renderer_context.get('view')
+        except AttributeError:
+            resource_name = False
+        else:
+            resource_name = get_resource_name(view)
 
-        if resource_name == False:
+        if resource_name is not False:
             return super(JSONRenderer, self).render(
                 data, accepted_media_type, renderer_context)
 


### PR DESCRIPTION
DRF's test runner sometimes calls `render` with no `renderer_context`,
causing RFE to throw an error. This commit makes that all better.